### PR TITLE
Add server environment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ The project is a monorepo managed with npm workspaces.
     ```
     This will install dependencies for both the client and server.
 
-2.  **Database Setup:**
+2.  **Environment Configuration:**
     - Navigate to the `/server` directory.
-    - Copy the `.env.example` file to a new file named `.env`.
-    - Update the `DATABASE_URL` and `JWT_SECRET` variables in the `.env` file with your PostgreSQL connection string and a strong secret key.
+    - Copy the `server/.env.example` file to a new file named `server/.env`.
+    - Update the `DATABASE_URL`, `JWT_SECRET` and `CORS_ORIGIN` values in `server/.env` with your desired settings.
 
 3.  **Run Database Migrations:** From the root directory, run:
     ```bash

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DBNAME
+JWT_SECRET=replace_with_strong_secret
+CORS_ORIGIN=http://localhost:5173


### PR DESCRIPTION
## Summary
- add `.env.example` with environment variable placeholders
- document copying and editing `.env.example` in README

## Testing
- `npm run build -w server` *(fails: `command sh -c tsc`)*

------
https://chatgpt.com/codex/tasks/task_e_6882270208808321a2e788ef102f394c