### PR TITLE
Update CORS config to use env origin

### DIFF
--- a/server/.env
+++ b/server/.env
@@ -1,2 +1,3 @@
 DATABASE_URL="file:./dev.db"
 JWT_SECRET="secret"
+CORS_ORIGIN=http://localhost:5173

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,7 +8,11 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 3001;
 
-app.use(cors());
+const allowedOrigins = process.env.CORS_ORIGIN
+  ? process.env.CORS_ORIGIN.split(',').map(origin => origin.trim())
+  : undefined;
+
+app.use(cors({ origin: allowedOrigins }));
 app.use(express.json());
 
 app.get('/', (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- read CORS origin list from `process.env.CORS_ORIGIN`
- default `.env` to include `CORS_ORIGIN` for local dev

## Testing
- `npm run build -w server` *(fails: TS6059 - seed.ts not under rootDir)*

------
https://chatgpt.com/codex/tasks/task_e_68833d28e89083219d674d2de7b03e92