### PR TITLE
Use cookies for auth

### DIFF
--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useState, useContext, useEffect, useCallback } from 'react';
 import { User } from '../types';
 import api from '../services/api';
+import { getCookie, setCookie, removeCookie } from '../utils/cookies';
 
 interface AuthContextType {
   user: User | null;
@@ -14,7 +15,7 @@ export const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
-  const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
+  const [token, setToken] = useState<string | null>(getCookie('token'));
   const [loading, setLoading] = useState(true);
 
   const fetchUser = useCallback(async () => {
@@ -25,7 +26,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         setUser(response.data);
       } catch (error) {
         console.error("Failed to fetch user", error);
-        localStorage.removeItem('token');
+        removeCookie('token');
         setToken(null);
         setUser(null);
       }
@@ -41,7 +42,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     try {
       const response = await api.post('/auth/login', { email, password });
       const { token: newToken, user: loggedInUser } = response.data;
-      localStorage.setItem('token', newToken);
+      setCookie('token', newToken);
       setToken(newToken);
       setUser(loggedInUser);
       api.defaults.headers.common['Authorization'] = `Bearer ${newToken}`;
@@ -53,7 +54,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   const logout = () => {
-    localStorage.removeItem('token');
+    removeCookie('token');
     setToken(null);
     setUser(null);
     delete api.defaults.headers.common['Authorization'];

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { getCookie } from '../utils/cookies';
 
 const api = axios.create({
   baseURL: (import.meta as any).env.VITE_API_URL || 'http://localhost:3001/api',
@@ -10,7 +11,7 @@ const api = axios.create({
 // Add a request interceptor to include the token in headers
 api.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('token');
+    const token = getCookie('token');
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }

--- a/client/src/utils/cookies.ts
+++ b/client/src/utils/cookies.ts
@@ -1,0 +1,13 @@
+export const getCookie = (name: string): string | null => {
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)')); 
+  return match ? decodeURIComponent(match[2]) : null;
+};
+
+export const setCookie = (name: string, value: string, days = 7): void => {
+  const expires = new Date(Date.now() + days * 864e5).toUTCString();
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/; secure; samesite=strict`;
+};
+
+export const removeCookie = (name: string): void => {
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;`;
+};


### PR DESCRIPTION
## Summary
- store auth token in cookies instead of localStorage
- update axios service to read token from cookies
- add small cookie utility helpers

## Testing
- `npm run build -w client` *(fails: cannot find many TS modules)*
- `npm run lint -w client` *(fails: couldn't find eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_6883460ba0c48321913e046d451cf917